### PR TITLE
Error when at end of file

### DIFF
--- a/wodpy/wod.py
+++ b/wodpy/wod.py
@@ -31,6 +31,9 @@ class WodProfile(object):
         self.file_name = fid.name
         self.file_position = fid.tell()
         
+        # Check we are not at the end of the file.
+        assert self.file_position < os.fstat(fid.fileno()).st_size, 'At end of data file.'
+        
         # Record if CR+LF characters are being used at the end of lines.
         fid.seek(self.file_position + 80)
         char = fid.read(1)


### PR DESCRIPTION
Added an assert statement so that a meaningful error message is returned if a user tries to read beyond the end of the file.

Or would it be better to return None in this case?
