### PR TITLE
byte / character mismatches

### DIFF
--- a/wodpy/wod.py
+++ b/wodpy/wod.py
@@ -36,10 +36,9 @@ class WodProfile(object):
         assert self.file_position < os.fstat(fid.fileno()).st_size, 'At end of data file.'
         
         # Record if CR+LF characters are being used at the end of lines.
-        fid.seek(self.file_position + 80)
-        char = fid.read(1)
-        if char == '\r': 
-            self.cr = True 
+        firstline = fid.readline()
+        if(fid.tell() == self.file_position + 82):
+            self.cr = True
         else:
             self.cr = False
         fid.seek(self.file_position)
@@ -90,7 +89,7 @@ class WodProfile(object):
             if item[1] == 0: continue # Skip if not reading anything.
 
             chars = self._read_chars(fid, item[1])
- 
+
             # Check if we need to skip the next few items.
             if item[0] == 'Significant digits' and chars == '-':
                 format[i+1][1] = 0


### PR DESCRIPTION
#13  pointed out some interesting behavior - things were breaking in Python 3.x with files with windows-flavored linebreaks.

It turns out that a 3.x feature was causing us to misidentify linebreaks. All files are opened in 3.x in 'universal line ending mode', which replaces `\r\n` with `\n` (you can reproduce this in 2.x with the `'U'` flag when opening a file). This produces surprising (to me) behavior when also traversing these files with `.seek()`. Try the following in 2.x or 3.x:

```
# made a dummy file with an \r\n linebreak:
data = open('rn.dat', 'w')
data.write('AB\r\nCD')
data.close()

# open in universal linebreak mode with 'U'
data = open('rn.dat', 'U')
# skip the 'AB' the file starts with; analogous to going 80 characters in on a WOD profile
data.seek(2)
# read and print the next character; it's \n, not \r
char = data.read(1)
print(repr(char))
# where it gets really weird IMO is if we go another character in; \n again!
data.seek(3)
char = data.read(1)
print(repr(char))
```

Change the `'U'` to a `'r'` in 2.x and the more obvious behavior (`\r` after seeking past 2 and `\n` after seeking past 3) returns. Don't do the `data.seek(3)` and just read the next character, and you'll get the `C`; seems like the substitution of `\r\n` -> `\n` is happening somewhere that `.seek` is circumventing.

This PR solves this issue by inferring the line break character from whether the first line is 81 or 82 characters long, sidestepping the odd behavior above. I'll leave this open for comments for a week before merging and stamping 1.4.0 with this and the updates in #14.

(cc @pajodu, I know you collect this kind of 'feature')