### PR TITLE
Originator flag types

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ These functions decode data from the current profile.
  - `PIs()`: Returns a list of objects with keys "Variable code" and "P.I. code"
  - `originator_station()`: Returns a string denoting the originator station
  - `originator_cruise()`: Returns a string denoting the originator cruise
+ - `originator_flag_type()`: Returns the index specifying the originator flag definitions (table 2.28 in http://data.nodc.noaa.gov/woa/WOD/DOC/wodreadme.pdf)
 
 **Per-level data:**
  - `oxygen()`: Returns a numpy masked array of oxygen content (mL / L).
@@ -140,6 +141,7 @@ Constructing the per-level `ndarrays` should not be done more than once per prof
  - `PIs`
  - `originator_station`
  - `originator_cruise`
+ - `originator_flag_type`
 
  Note that `DataFrame` attributes generally do not propagate to new `DataFrames` returned by operating on original `DataFrame`s.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ These functions decode data from the current profile.
  - `originator_station()`: Returns a string denoting the originator station
  - `originator_cruise()`: Returns a string denoting the originator cruise
  - `originator_flag_type()`: Returns the index specifying the originator flag definitions (table 2.28 in http://data.nodc.noaa.gov/woa/WOD/DOC/wodreadme.pdf)
+ - `extract_secondary_header(index)`: returns the value of the secondary header indexed by the `index` argument, where this index corresponds to the 'ID' column of table 4 in https://data.nodc.noaa.gov/woa/WOD/DOC/wodreadme.pdf. For example, `extract_secondary_header(29)` is exactly equivalent to `probe_type()`.
 
 **Per-level data:**
  - `oxygen()`: Returns a numpy masked array of oxygen content (mL / L).

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -19,7 +19,7 @@ class TestClass():
         return
 
     # ===================================================================
-    # check the example from pp 137 of
+    # check the example from pp 124 of
     # http://data.nodc.noaa.gov/woa/WOD/DOC/wodreadme.pdf
     # is extracted correctly by base functions.
     # data is in `example.dat`

--- a/wodpy/wod.py
+++ b/wodpy/wod.py
@@ -447,14 +447,24 @@ class WodProfile(object):
 
         return station
 
+    def extract_secondary_header(self, index):
+        """ Returns the contents of secondary header <index> if it exists,
+            otherwise None. """
+        header = None
+        for item in self.secondary_header['entries']:
+            if item['Code'] == index:
+                header = item['Value']
+        return header  
+
+    def originator_flag_type(self):
+        """ Returns the contents of secondary header 96 if it exists,
+            otherwise None. """
+        return extract_secondary_header(96)
+
     def probe_type(self):
         """ Returns the contents of secondary header 29 if it exists,
             otherwise None. """
-        pt = None
-        for item in self.secondary_header['entries']:
-            if item['Code'] == 29:
-                pt = item['Value']
-        return pt
+        return extract_secondary_header(29)
 
     def z(self):
         """ Returns a numpy masked array of depths. """

--- a/wodpy/wod.py
+++ b/wodpy/wod.py
@@ -459,12 +459,12 @@ class WodProfile(object):
     def originator_flag_type(self):
         """ Returns the contents of secondary header 96 if it exists,
             otherwise None. """
-        return extract_secondary_header(96)
+        return self.extract_secondary_header(96)
 
     def probe_type(self):
         """ Returns the contents of secondary header 29 if it exists,
             otherwise None. """
-        return extract_secondary_header(29)
+        return self.extract_secondary_header(29)
 
     def z(self):
         """ Returns a numpy masked array of depths. """
@@ -649,6 +649,7 @@ class WodProfile(object):
         df.time = self.time()
         df.cruise = self.cruise()
         df.probe_type = self.probe_type()
+        df.originator_flag_type = self.originator_flag_type()
         df.PIs = self.PIs()
         df.originator_station = self.originator_station()
         df.originator_cruise = self.originator_cruise()
@@ -678,6 +679,7 @@ class WodProfile(object):
         d['PIs'] = self.PIs()
         d['originator_station'] = self.originator_station()
         d['originator_cruise'] = self.originator_cruise()
+        d['originator_flag_type'] = self.originator_flag_type()
         # per level
         d['s'] = self.s()
         d['s_level_qc'] = self.s_level_qc()


### PR DESCRIPTION
It's long been possible to ask for the originator QC flags from wodpy, but without the index corresponding to the 'WOD Code' column of table 2.28 in https://data.nodc.noaa.gov/woa/WOD/DOC/wodreadme.pdf, these flags cannot be interpreted, if I understand the specification correctly. This PR introduces a function to pull the originator flag type out of the secondary header to solve this.

Note this will be necessary in order to isolate a collection of WOD-ASCII profiles that have meaningful originator flags and therefore exactly reliable QC data, per @BecCowley's suggestion (again if I've understood correctly). @s-good, let me know if this all looks good to you - thanks!